### PR TITLE
Bump `ghostwriter/uuid` from `1.0.1` to `1.0.2`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "ghostwriter/result": "^1.3.0",
         "ghostwriter/shell": "^0.1.0",
         "ghostwriter/testify": "^0.1.0",
-        "ghostwriter/uuid": "^1.0.1"
+        "ghostwriter/uuid": "^1.0.2"
     },
     "require-dev": {
         "ghostwriter/coding-standard": "dev-main",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "58a6dbb1b316e8abf642540a53c8f777",
+    "content-hash": "b99e8fc67057f65c42a3bbf3977f2447",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -1526,16 +1526,16 @@
         },
         {
             "name": "ghostwriter/uuid",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/uuid.git",
-                "reference": "bece9c34ccf981fc65150cde0087cd5af57c6603"
+                "reference": "0867b6c92d5e2973c87ad13f88aae66f39ce7dd6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/uuid/zipball/bece9c34ccf981fc65150cde0087cd5af57c6603",
-                "reference": "bece9c34ccf981fc65150cde0087cd5af57c6603",
+                "url": "https://api.github.com/repos/ghostwriter/uuid/zipball/0867b6c92d5e2973c87ad13f88aae66f39ce7dd6",
+                "reference": "0867b6c92d5e2973c87ad13f88aae66f39ce7dd6",
                 "shasum": ""
             },
             "require": {
@@ -1543,7 +1543,8 @@
                 "php": ">=8.3"
             },
             "require-dev": {
-                "ghostwriter/coding-standard": "dev-main"
+                "ghostwriter/coding-standard": "dev-main",
+                "ghostwriter/handrail": "dev-main"
             },
             "type": "library",
             "autoload": {
@@ -1570,8 +1571,6 @@
                 "uuid"
             ],
             "support": {
-                "docs": "https://github.com/ghostwriter/uuid",
-                "forum": "https://github.com/ghostwriter/uuid/discussions",
                 "issues": "https://github.com/ghostwriter/uuid/issues",
                 "rss": "https://github.com/ghostwriter/uuid/releases.atom",
                 "security": "https://github.com/ghostwriter/uuid/security/advisories/new",
@@ -1583,7 +1582,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-21T21:08:22+00:00"
+            "time": "2025-01-28T18:15:13+00:00"
         },
         {
             "name": "justinrainbow/json-schema",


### PR DESCRIPTION
Bumps `ghostwriter/uuid` from `1.0.1` to `1.0.2`.

- Update `composer.json`
- Update `composer.lock`