### PR TITLE
Bump `ghostwriter/uuid` from `1.0.2` to `1.0.3`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "ghostwriter/option": "^2.0.0",
         "ghostwriter/result": "^2.0.0",
         "ghostwriter/shell": "^0.1.0",
-        "ghostwriter/uuid": "^1.0.2"
+        "ghostwriter/uuid": "^1.0.3"
     },
     "require-dev": {
         "ghostwriter/coding-standard": "dev-main",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "88f6e128ed27d27eef4ca83c7563c69b",
+    "content-hash": "d77d1a7d086e57a06d978eace09292cf",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -737,25 +737,24 @@
         },
         {
             "name": "ghostwriter/uuid",
-            "version": "1.0.2",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/uuid.git",
-                "reference": "0867b6c92d5e2973c87ad13f88aae66f39ce7dd6"
+                "reference": "3e34ec75ee18aa4a7cf9b20bc821dc572d1209b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/uuid/zipball/0867b6c92d5e2973c87ad13f88aae66f39ce7dd6",
-                "reference": "0867b6c92d5e2973c87ad13f88aae66f39ce7dd6",
+                "url": "https://api.github.com/repos/ghostwriter/uuid/zipball/3e34ec75ee18aa4a7cf9b20bc821dc572d1209b9",
+                "reference": "3e34ec75ee18aa4a7cf9b20bc821dc572d1209b9",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "php": ">=8.3"
+                "php": "^8.4"
             },
             "require-dev": {
-                "ghostwriter/coding-standard": "dev-main",
-                "ghostwriter/handrail": "dev-main"
+                "ghostwriter/coding-standard": "dev-main"
             },
             "type": "library",
             "autoload": {
@@ -782,6 +781,7 @@
                 "uuid"
             ],
             "support": {
+                "docs": "https://github.com/ghostwriter/uuid",
                 "issues": "https://github.com/ghostwriter/uuid/issues",
                 "rss": "https://github.com/ghostwriter/uuid/releases.atom",
                 "security": "https://github.com/ghostwriter/uuid/security/advisories/new",
@@ -793,7 +793,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-01-28T18:15:13+00:00"
+            "time": "2025-03-17T20:27:11+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
Bumps `ghostwriter/uuid` from `1.0.2` to `1.0.3`.

- Update `composer.json`
- Update `composer.lock`