### PR TITLE
Update ghostwriter/coding-standard to version dev-main#776cfbd

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2299,42 +2299,68 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "37e10b19a241ffac3d608c033bc6fc56865712e3"
+                "reference": "776cfbdf9f48c7cff70ef4dc836d06de24266e99"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/37e10b19a241ffac3d608c033bc6fc56865712e3",
-                "reference": "37e10b19a241ffac3d608c033bc6fc56865712e3",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/776cfbdf9f48c7cff70ef4dc836d06de24266e99",
+                "reference": "776cfbdf9f48c7cff70ef4dc836d06de24266e99",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "~2.9.0",
                 "composer-runtime-api": "~2.2.2",
                 "composer/composer": "^2.9.2",
+                "ext-apcu": "*",
+                "ext-bcmath": "*",
                 "ext-ctype": "*",
                 "ext-curl": "*",
                 "ext-dom": "*",
+                "ext-ds": "*",
+                "ext-event": "*",
+                "ext-exif": "*",
+                "ext-fileinfo": "*",
                 "ext-filter": "*",
                 "ext-gd": "*",
+                "ext-gettext": "*",
                 "ext-hash": "*",
                 "ext-iconv": "*",
+                "ext-igbinary": "*",
                 "ext-intl": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
+                "ext-memcache": "*",
+                "ext-mysqli": "*",
                 "ext-openssl": "*",
+                "ext-pcntl": "*",
+                "ext-pdo": "*",
+                "ext-pdo_mysql": "*",
+                "ext-pdo_pgsql": "*",
+                "ext-pdo_sqlite": "*",
+                "ext-pgsql": "*",
                 "ext-phar": "*",
+                "ext-posix": "*",
+                "ext-protobuf": "*",
                 "ext-readline": "*",
+                "ext-redis": "*",
                 "ext-session": "*",
                 "ext-simplexml": "*",
                 "ext-sockets": "*",
                 "ext-sodium": "*",
+                "ext-sqlite3": "*",
                 "ext-tokenizer": "*",
                 "ext-xml": "*",
+                "ext-xmlreader": "*",
                 "ext-xmlwriter": "*",
+                "ext-xsl": "*",
+                "ext-yaml": "*",
+                "ext-zend-opcache": "*",
+                "ext-zip": "*",
                 "ext-zlib": "*",
+                "ghostwriter/console": "^0.1.2",
                 "php": "~8.4.0 || ~8.5.0",
-                "symfony/console": "^8.0.0"
+                "symfony/process": "^8.0.0"
             },
             "conflict": {
                 "pestphp/pest": "*"
@@ -2408,6 +2434,9 @@
                             "zetacomponents",
                             "zf-commons"
                         ]
+                    },
+                    "container": {
+                        "definition": "Ghostwriter\\CodingStandard\\Container\\CodingStandardDefinition"
                     }
                 },
                 "plugin-optional": false,
@@ -2452,7 +2481,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-27T10:34:03+00:00"
+            "time": "2025-11-28T01:32:02+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -5120,20 +5149,20 @@
         },
         {
             "name": "symfony/process",
-            "version": "v7.3.4",
+            "version": "v8.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "f24f8f316367b30810810d4eb30c543d7003ff3b"
+                "reference": "a0a750500c4ce900d69ba4e9faf16f82c10ee149"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/f24f8f316367b30810810d4eb30c543d7003ff3b",
-                "reference": "f24f8f316367b30810810d4eb30c543d7003ff3b",
+                "url": "https://api.github.com/repos/symfony/process/zipball/a0a750500c4ce900d69ba4e9faf16f82c10ee149",
+                "reference": "a0a750500c4ce900d69ba4e9faf16f82c10ee149",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.4"
             },
             "type": "library",
             "autoload": {
@@ -5161,7 +5190,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.3.4"
+                "source": "https://github.com/symfony/process/tree/v8.0.0"
             },
             "funding": [
                 {
@@ -5181,7 +5210,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-11T10:12:26+00:00"
+            "time": "2025-10-16T16:25:44+00:00"
         },
         {
             "name": "symfony/var-dumper",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#37e10b1` to `dev-main#776cfbd`.

This pull request changes the following file(s): 

- Update `composer.lock`