### PR TITLE
Update ghostwriter/coding-standard to version dev-main#e6d2295

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2299,12 +2299,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "e118fcb1d5e222e52deb6d92405c2075a919e230"
+                "reference": "e6d22955e961fe3d953c5a6ead6f4b13f235c0a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/e118fcb1d5e222e52deb6d92405c2075a919e230",
-                "reference": "e118fcb1d5e222e52deb6d92405c2075a919e230",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/e6d22955e961fe3d953c5a6ead6f4b13f235c0a3",
+                "reference": "e6d22955e961fe3d953c5a6ead6f4b13f235c0a3",
                 "shasum": ""
             },
             "require": {
@@ -2480,7 +2480,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-05T05:29:35+00:00"
+            "time": "2025-12-06T03:46:42+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#e118fcb` to `dev-main#e6d2295`.

This pull request changes the following file(s): 

- Update `composer.lock`