### PR TITLE
Update ghostwriter/coding-standard to version dev-main#cbd9546

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2299,12 +2299,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "d0b2d2d508f8afb6974f640eab8e1b118c76c956"
+                "reference": "cbd9546ff30ca4f1028217faa00efa5688341e32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/d0b2d2d508f8afb6974f640eab8e1b118c76c956",
-                "reference": "d0b2d2d508f8afb6974f640eab8e1b118c76c956",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/cbd9546ff30ca4f1028217faa00efa5688341e32",
+                "reference": "cbd9546ff30ca4f1028217faa00efa5688341e32",
                 "shasum": ""
             },
             "require": {
@@ -2333,14 +2333,12 @@
                 "ext-memcache": "*",
                 "ext-mysqli": "*",
                 "ext-openssl": "*",
-                "ext-pcntl": "*",
                 "ext-pdo": "*",
                 "ext-pdo_mysql": "*",
                 "ext-pdo_pgsql": "*",
                 "ext-pdo_sqlite": "*",
                 "ext-pgsql": "*",
                 "ext-phar": "*",
-                "ext-posix": "*",
                 "ext-protobuf": "*",
                 "ext-readline": "*",
                 "ext-redis": "*",
@@ -2480,7 +2478,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-06T17:05:14+00:00"
+            "time": "2025-12-07T12:17:26+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#d0b2d2d` to `dev-main#cbd9546`.

This pull request changes the following file(s): 

- Update `composer.lock`