### PR TITLE
Update boundwize/structarmed to version 0.6.17

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.6.16",
+        "boundwize/structarmed": "^0.6.17",
         "ghostwriter/coding-standard": "dev-main",
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^13.1.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "296eadf4edd4df3514aa5eade3dfa31e",
+    "content-hash": "06cfe4ffdc8470cd08dc384d6004c7b0",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -2708,16 +2708,16 @@
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.6.16",
+            "version": "0.6.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "8df4838a8266ed13867f9647ac52d98fc5a307d4"
+                "reference": "bb3f33323796807af7b3d9f439d6a6f2d9066afc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/8df4838a8266ed13867f9647ac52d98fc5a307d4",
-                "reference": "8df4838a8266ed13867f9647ac52d98fc5a307d4",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/bb3f33323796807af7b3d9f439d6a6f2d9066afc",
+                "reference": "bb3f33323796807af7b3d9f439d6a6f2d9066afc",
                 "shasum": ""
             },
             "require": {
@@ -2766,7 +2766,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.6.16"
+                "source": "https://github.com/boundwize/structarmed/tree/0.6.17"
             },
             "funding": [
                 {
@@ -2774,7 +2774,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-21T05:21:20+00:00"
+            "time": "2026-05-21T09:45:33+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",
@@ -2843,12 +2843,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "f40d7d3a923f6645a95b736fdeb625399bc8b0bb"
+                "reference": "a487cba2776adef9c40032ddea6072105f063b09"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/f40d7d3a923f6645a95b736fdeb625399bc8b0bb",
-                "reference": "f40d7d3a923f6645a95b736fdeb625399bc8b0bb",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/a487cba2776adef9c40032ddea6072105f063b09",
+                "reference": "a487cba2776adef9c40032ddea6072105f063b09",
                 "shasum": ""
             },
             "require": {
@@ -2963,7 +2963,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-21T06:37:46+00:00"
+            "time": "2026-05-21T09:25:21+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.6.16` to `0.6.17`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`