### PR TITLE
Update ghostwriter/clock to version 3.0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "php": "~8.4.0 || ~8.5.0",
         "ext-mbstring": "*",
         "ghostwriter/case-converter": "^2.2.2",
-        "ghostwriter/clock": "^3.0.1",
+        "ghostwriter/clock": "^3.0.2",
         "ghostwriter/collection": "^2.1.0",
         "ghostwriter/config": "^2.1.3",
         "ghostwriter/console": "^0.2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "22bbb9115bacb16f90e952c6bd4fed1d",
+    "content-hash": "00d1ee89e7cc15b479088e95e99aa756",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -97,26 +97,47 @@
         },
         {
             "name": "ghostwriter/clock",
-            "version": "3.0.1",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/clock.git",
-                "reference": "e68368475feb957b7d40e3d1e03de411fe6b032d"
+                "reference": "ee705b50da2f6d285fa2563207b7487a9f73b865"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/clock/zipball/e68368475feb957b7d40e3d1e03de411fe6b032d",
-                "reference": "e68368475feb957b7d40e3d1e03de411fe6b032d",
+                "url": "https://api.github.com/repos/ghostwriter/clock/zipball/ee705b50da2f6d285fa2563207b7487a9f73b865",
+                "reference": "ee705b50da2f6d285fa2563207b7487a9f73b865",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.3"
+                "ext-mbstring": "*",
+                "php": "~8.4.0 || ~8.5.0",
+                "psr/clock": "^1.0.0"
             },
             "require-dev": {
+                "boundwize/structarmed": "^0.7.12",
+                "ext-xdebug": "*",
                 "ghostwriter/coding-standard": "dev-main",
-                "ghostwriter/psalm-plugin": "dev-main"
+                "ghostwriter/container": "^7.0.2",
+                "ghostwriter/testify": "^0.1.1",
+                "mockery/mockery": "^1.6.12",
+                "phpunit/phpunit": "^13.1.12",
+                "symfony/var-dumper": "^8.0.8"
             },
             "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/ghostwriter/clock",
+                    "name": "ghostwriter/clock"
+                },
+                "ghostwriter": {
+                    "container": {
+                        "provider": [
+                            "Ghostwriter\\Clock\\Container\\ClockProvider"
+                        ]
+                    }
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Ghostwriter\\Clock\\": "src/"
@@ -152,7 +173,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-01-05T19:26:41+00:00"
+            "time": "2026-05-27T07:46:54+00:00"
         },
         {
             "name": "ghostwriter/collection",
@@ -1701,6 +1722,54 @@
                 }
             ],
             "time": "2025-10-12T15:31:36+00:00"
+        },
+        {
+            "name": "psr/clock",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/clock.git",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/clock/zipball/e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Clock\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for reading the clock.",
+            "homepage": "https://github.com/php-fig/clock",
+            "keywords": [
+                "clock",
+                "now",
+                "psr",
+                "psr-20",
+                "time"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/clock/issues",
+                "source": "https://github.com/php-fig/clock/tree/1.0.0"
+            },
+            "time": "2022-11-25T14:36:26+00:00"
         },
         {
             "name": "psr/container",


### PR DESCRIPTION
Updates the `ghostwriter/clock` dependency from `3.0.1` to `3.0.2`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`