### PR TITLE
Update `boundwize/structarmed` to version `0.12.1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.12.0",
+        "boundwize/structarmed": "^0.12.1",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/phpunit-assertions": "^0.1.0",
         "ghostwriter/testify": "^0.1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e479cb5f883292ebf6a40928f51590cd",
+    "content-hash": "bad5dd512db97403495d56d272112187",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -2933,16 +2933,16 @@
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.12.0",
+            "version": "0.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "e3b038b0675e0b1e3c056dc8e4ffcbab15b39bf8"
+                "reference": "163d33656d20a19d41e51decb25129923a750f87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/e3b038b0675e0b1e3c056dc8e4ffcbab15b39bf8",
-                "reference": "e3b038b0675e0b1e3c056dc8e4ffcbab15b39bf8",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/163d33656d20a19d41e51decb25129923a750f87",
+                "reference": "163d33656d20a19d41e51decb25129923a750f87",
                 "shasum": ""
             },
             "require": {
@@ -2991,11 +2991,12 @@
                 "psr1",
                 "psr12",
                 "psr15",
-                "psr4"
+                "psr4",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.12.0"
+                "source": "https://github.com/boundwize/structarmed/tree/0.12.1"
             },
             "funding": [
                 {
@@ -3003,7 +3004,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-05T02:51:34+00:00"
+            "time": "2026-06-05T19:03:15+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",


### PR DESCRIPTION
Updates the [`boundwize/structarmed`](https://packagist.org/packages/boundwize/structarmed) dependency from `0.12.0` to `0.12.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`