### PR TITLE
Update `ghostwriter/coding-standard` to version `dev-main#a5b6727`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3252,12 +3252,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "774069dcb8f9b6d25918708b1a277ac4d6024b73"
+                "reference": "a5b672744984c25b10cea76bd590701a01b254c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/774069dcb8f9b6d25918708b1a277ac4d6024b73",
-                "reference": "774069dcb8f9b6d25918708b1a277ac4d6024b73",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/a5b672744984c25b10cea76bd590701a01b254c1",
+                "reference": "a5b672744984c25b10cea76bd590701a01b254c1",
                 "shasum": ""
             },
             "require": {
@@ -3361,7 +3361,7 @@
                     "type": "paypal"
                 }
             ],
-            "time": "2026-07-07T04:07:55+00:00"
+            "time": "2026-07-16T13:58:43+00:00"
         },
         {
             "name": "ghostwriter/phpunit-assertions",


### PR DESCRIPTION
Updates the [`ghostwriter/coding-standard`](https://packagist.org/packages/ghostwriter/coding-standard) dependency from `dev-main#774069d` to `dev-main#a5b6727`.

This pull request changes the following file(s): 

- Update `composer.lock`